### PR TITLE
feat(categories): create & manage saving categories (Room+Compose); schema export; nav route

### DIFF
--- a/FinancialApp/.gitignore
+++ b/FinancialApp/.gitignore
@@ -1,0 +1,1 @@
+local.properties

--- a/FinancialApp/app/build.gradle.kts
+++ b/FinancialApp/app/build.gradle.kts
@@ -2,7 +2,15 @@ plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
+    alias(libs.plugins.ksp)
 }
+
+ksp {
+    arg("room.schemaLocation", "$projectDir/schemas")
+    arg("room.incremental", "true")
+    arg("room.generateKotlin", "true")
+}
+
 
 android {
     namespace = "com.example.financialapp"
@@ -28,11 +36,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = "11"
+        jvmTarget = "17"
     }
     buildFeatures {
         compose = true
@@ -56,4 +64,16 @@ dependencies {
     androidTestImplementation(libs.androidx.ui.test.junit4)
     debugImplementation(libs.androidx.ui.tooling)
     debugImplementation(libs.androidx.ui.test.manifest)
+
+    // Navigation
+    implementation(libs.androidx.navigation.compose)
+
+    // Room
+    implementation(libs.androidx.room.runtime)
+    implementation(libs.androidx.room.ktx)
+    ksp(libs.androidx.room.compiler)
+
+    // coroutines (flows + tests)
+    implementation(libs.kotlinx.coroutines.android)
+    testImplementation(libs.kotlinx.coroutines.test)
 }

--- a/FinancialApp/app/schemas/com.example.financialapp.data.AppDatabase/1.json
+++ b/FinancialApp/app/schemas/com.example.financialapp.data.AppDatabase/1.json
@@ -1,0 +1,58 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 1,
+    "identityHash": "a23a0db66a927f8f4eb53ce33c597779",
+    "entities": [
+      {
+        "tableName": "saving_categories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `colorHex` TEXT NOT NULL, `goalAmount` REAL NOT NULL, `savedAmount` REAL NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "colorHex",
+            "columnName": "colorHex",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "goalAmount",
+            "columnName": "goalAmount",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "savedAmount",
+            "columnName": "savedAmount",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'a23a0db66a927f8f4eb53ce33c597779')"
+    ]
+  }
+}

--- a/FinancialApp/app/src/main/java/com/example/financialapp/MainActivity.kt
+++ b/FinancialApp/app/src/main/java/com/example/financialapp/MainActivity.kt
@@ -7,41 +7,41 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import com.example.financialapp.ui.category.CategoryListScreen
 import com.example.financialapp.ui.theme.FinancialAppTheme
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
-        setContent {
-            FinancialAppTheme {
-                Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-                    Greeting(
-                        name = "Android",
-                        modifier = Modifier.padding(innerPadding)
-                    )
-                }
+        setContent { AppRoot() }
+    }
+}
+
+@Composable
+fun AppRoot() {
+    FinancialAppTheme {
+        val nav = rememberNavController()
+        Scaffold(modifier = Modifier.fillMaxSize()) { inner ->
+            NavHost(
+                navController = nav,
+                startDestination = "categories",
+                modifier = Modifier.padding(inner)
+            ) {
+                composable("categories") { CategoryListScreen() }
             }
         }
     }
 }
 
-@Composable
-fun Greeting(name: String, modifier: Modifier = Modifier) {
-    Text(
-        text = "Hello $name!",
-        modifier = modifier
-    )
-}
-
 @Preview(showBackground = true)
 @Composable
-fun GreetingPreview() {
-    FinancialAppTheme {
-        Greeting("Android")
-    }
+private fun AppRootPreview() {
+    AppRoot()
 }

--- a/FinancialApp/app/src/main/java/com/example/financialapp/data/AppDatabase.kt
+++ b/FinancialApp/app/src/main/java/com/example/financialapp/data/AppDatabase.kt
@@ -1,0 +1,15 @@
+package com.example.financialapp.data
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+import com.example.financialapp.data.category.SavingCategory
+import com.example.financialapp.data.category.SavingCategoryDao
+
+@Database(
+    entities = [SavingCategory::class],
+    version = 1,
+    exportSchema = true
+)
+abstract class AppDatabase : RoomDatabase() {
+    abstract fun savingCategoryDao(): SavingCategoryDao
+}

--- a/FinancialApp/app/src/main/java/com/example/financialapp/data/DatabaseModule.kt
+++ b/FinancialApp/app/src/main/java/com/example/financialapp/data/DatabaseModule.kt
@@ -1,0 +1,17 @@
+package com.example.financialapp.data
+
+import android.content.Context
+import androidx.room.Room
+
+object DatabaseModule {
+    @Volatile private var instance: AppDatabase? = null
+
+    fun db(context: Context): AppDatabase =
+        instance ?: synchronized(this) {
+            instance ?: Room.databaseBuilder(
+                context.applicationContext,
+                AppDatabase::class.java,
+                "financial-db"
+            ).fallbackToDestructiveMigration().build().also { instance = it }
+        }
+}

--- a/FinancialApp/app/src/main/java/com/example/financialapp/data/category/SavingCategory.kt
+++ b/FinancialApp/app/src/main/java/com/example/financialapp/data/category/SavingCategory.kt
@@ -1,0 +1,13 @@
+package com.example.financialapp.data.category
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "saving_categories")
+data class SavingCategory(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    val name: String,
+    val colorHex: String,     // "#FF6D00"
+    val goalAmount: Double,   // editable per acceptance criteria
+    val savedAmount: Double = 0.0
+)

--- a/FinancialApp/app/src/main/java/com/example/financialapp/data/category/SavingCategoryDao.kt
+++ b/FinancialApp/app/src/main/java/com/example/financialapp/data/category/SavingCategoryDao.kt
@@ -1,0 +1,22 @@
+package com.example.financialapp.data.category
+
+import androidx.room.*
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface SavingCategoryDao {
+    @Query("SELECT * FROM saving_categories ORDER BY name")
+    fun observeAll(): Flow<List<SavingCategory>>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(category: SavingCategory): Long
+
+    @Update
+    suspend fun update(category: SavingCategory)
+
+    @Query("SELECT * FROM saving_categories WHERE id = :id")
+    suspend fun getById(id: Long): SavingCategory?
+
+    @Delete
+    suspend fun delete(category: SavingCategory)
+}

--- a/FinancialApp/app/src/main/java/com/example/financialapp/data/category/SavingCategoryRepository.kt
+++ b/FinancialApp/app/src/main/java/com/example/financialapp/data/category/SavingCategoryRepository.kt
@@ -1,0 +1,15 @@
+package com.example.financialapp.data.category
+
+import kotlinx.coroutines.flow.Flow
+
+class SavingCategoryRepository(private val dao: SavingCategoryDao) {
+    fun observeAll(): Flow<List<SavingCategory>> = dao.observeAll()
+
+    suspend fun create(name: String, colorHex: String, goal: Double) =
+        dao.upsert(SavingCategory(name = name, colorHex = colorHex, goalAmount = goal))
+
+    suspend fun updateGoal(id: Long, newGoal: Double) {
+        val current = dao.getById(id) ?: return
+        dao.update(current.copy(goalAmount = newGoal))
+    }
+}

--- a/FinancialApp/app/src/main/java/com/example/financialapp/ui/category/CategoryScreens.kt
+++ b/FinancialApp/app/src/main/java/com/example/financialapp/ui/category/CategoryScreens.kt
@@ -1,0 +1,141 @@
+package com.example.financialapp.ui.category
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+
+import androidx.compose.material3.HorizontalDivider
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun CategoryListScreen(
+    vm: SavingCategoryViewModel = viewModel()
+) {
+    val items by vm.categories.collectAsState()
+
+    var showAdd by remember { mutableStateOf(false) }
+    var editId by remember { mutableStateOf<Long?>(null) }
+
+    Scaffold(
+        topBar = { TopAppBar(title = { Text("Saving Categories") }) },
+        floatingActionButton = {
+            FloatingActionButton(onClick = { showAdd = true }) { Text("+") }
+        }
+    ) { pad ->
+        LazyColumn(
+            contentPadding = pad,
+            modifier = Modifier.fillMaxSize()
+        ) {
+            items(items, key = { it.id }) { c ->
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable { editId = c.id }
+                        .padding(16.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .size(20.dp)
+                            .background(Color(android.graphics.Color.parseColor(c.colorHex)))
+                    )
+                    Spacer(Modifier.width(12.dp))
+                    Column(Modifier.weight(1f)) {
+                        Text(c.name, style = MaterialTheme.typography.titleMedium)
+                        Text("Goal: $${"%.2f".format(c.goal)}",
+                            style = MaterialTheme.typography.bodyMedium)
+                    }
+                }
+                HorizontalDivider()
+            }
+        }
+    }
+
+    if (showAdd) AddCategoryDialog(
+        onDismiss = { showAdd = false },
+        onConfirm = { name, color, goal ->
+            vm.create(name, color, goal); showAdd = false
+        }
+    )
+
+    val currentEdit = items.firstOrNull { it.id == editId }
+    if (currentEdit != null) EditGoalDialog(
+        category = currentEdit,
+        onDismiss = { editId = null },
+        onConfirm = { newGoal ->
+            vm.updateGoal(currentEdit.id, newGoal); editId = null
+        }
+    )
+}
+
+@Composable
+private fun AddCategoryDialog(
+    onDismiss: () -> Unit,
+    onConfirm: (name: String, colorHex: String, goalText: String) -> Unit
+) {
+    var name by remember { mutableStateOf("") }
+    var goal by remember { mutableStateOf("") }
+    val palette = listOf("#FF6D00", "#2962FF", "#00C853", "#AA00FF", "#D50000")
+    var selected by remember { mutableStateOf(palette.first()) }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("New Category") },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                OutlinedTextField(value = name, onValueChange = { name = it }, label = { Text("Name") })
+                OutlinedTextField(
+                    value = goal, onValueChange = { goal = it },
+                    label = { Text("Goal amount") },
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)
+                )
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    palette.forEach { hex ->
+                        val c = Color(android.graphics.Color.parseColor(hex))
+                        Box(
+                            modifier = Modifier
+                                .size(if (hex == selected) 28.dp else 24.dp)
+                                .background(c)
+                                .clickable { selected = hex }
+                        )
+                    }
+                }
+            }
+        },
+        confirmButton = { TextButton(onClick = { onConfirm(name, selected, goal) }) { Text("Save") } },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } }
+    )
+}
+
+@Composable
+private fun EditGoalDialog(
+    category: CategoryUi,
+    onDismiss: () -> Unit,
+    onConfirm: (goalText: String) -> Unit
+) {
+    var goal by remember { mutableStateOf(category.goal.toString()) }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Edit Goal • ${category.name}") },
+        text = {
+            OutlinedTextField(
+                value = goal, onValueChange = { goal = it },
+                label = { Text("New goal amount") },
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)
+            )
+        },
+        confirmButton = { TextButton(onClick = { onConfirm(goal) }) { Text("Update") } },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } }
+    )
+}

--- a/FinancialApp/app/src/main/java/com/example/financialapp/ui/category/SavingCategoryViewModel.kt
+++ b/FinancialApp/app/src/main/java/com/example/financialapp/ui/category/SavingCategoryViewModel.kt
@@ -1,0 +1,46 @@
+package com.example.financialapp.ui.category
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.financialapp.data.DatabaseModule
+import com.example.financialapp.data.category.SavingCategory
+import com.example.financialapp.data.category.SavingCategoryRepository
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+
+data class CategoryUi(
+    val id: Long,
+    val name: String,
+    val colorHex: String,
+    val goal: Double
+)
+
+class SavingCategoryViewModel(app: Application) : AndroidViewModel(app) {
+    private val repo by lazy {
+        val dao = DatabaseModule.db(app).savingCategoryDao()
+        SavingCategoryRepository(dao)
+    }
+
+    val categories: StateFlow<List<CategoryUi>> =
+        repo.observeAll()
+            .map { list -> list.map { it.toUi() } }
+            .stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
+
+    fun create(name: String, colorHex: String, goalText: String) = viewModelScope.launch {
+        val g = goalText.toDoubleOrNull() ?: 0.0
+        if (name.isNotBlank()) repo.create(name.trim(), colorHex, g)
+    }
+
+    fun updateGoal(id: Long, goalText: String) = viewModelScope.launch {
+        val g = goalText.toDoubleOrNull() ?: return@launch
+        repo.updateGoal(id, g)
+    }
+
+    private fun SavingCategory.toUi() = CategoryUi(
+        id = id, name = name, colorHex = colorHex, goal = goalAmount
+    )
+}

--- a/FinancialApp/build.gradle.kts
+++ b/FinancialApp/build.gradle.kts
@@ -3,4 +3,5 @@ plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.compose) apply false
+    alias(libs.plugins.ksp) apply false
 }

--- a/FinancialApp/gradle/libs.versions.toml
+++ b/FinancialApp/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.12.2"
+agp = "8.13.0"
 kotlin = "2.0.21"
 coreKtx = "1.17.0"
 junit = "4.13.2"
@@ -8,6 +8,11 @@ espressoCore = "3.7.0"
 lifecycleRuntimeKtx = "2.9.3"
 activityCompose = "1.10.1"
 composeBom = "2024.09.00"
+
+navigationCompose = "2.8.0"
+room = "2.6.1"
+coroutines = "1.9.0"
+ksp = "2.0.21-1.0.25"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -25,8 +30,23 @@ androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-man
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
 
+# Navigation
+androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
+
+# Room
+androidx-room-runtime   = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
+androidx-room-ktx       = { group = "androidx.room", name = "room-ktx",     version.ref = "room" }
+androidx-room-compiler  = { group = "androidx.room", name = "room-compiler", version.ref = "room" }
+
+# Coroutines (useful with Room/Flow + tests)
+kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "coroutines" }
+kotlinx-coroutines-test    = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test",    version.ref = "coroutines" }
+
+
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+
+ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 


### PR DESCRIPTION
### Summary
Add Saving Categories with Room persistence and Compose UI.

### Changes
- Entity/DAO: SavingCategory (name, colorHex, goalAmount, savedAmount)
- Repository + ViewModel
- Screens: list (+ FAB to add), edit-goal dialog
- Navigation route: "categories"
- KSP args for Room schema, schemas committed

### Acceptance Criteria
- Create: entering name + choosing color + goal saves the category.
- Edit: updating the goal amount persists.

### How to Test
1) Run app → categories screen.
2) Tap + → enter Name + pick Color + Goal → Save.
3) Tap item → change Goal → Update.
4) Kill and relaunch app → data persists.

### Notes
- AppDatabase version = 1 (schemas exported).
